### PR TITLE
fix: cria o diretório "imagens", caso ele não exista

### DIFF
--- a/SmartMenu.Server/Program.cs
+++ b/SmartMenu.Server/Program.cs
@@ -52,12 +52,19 @@ namespace SmartMenu.Server
             }
 
             app.UseHttpsRedirection();
-            app.UseStaticFiles(new StaticFileOptions
+
+            try {
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    FileProvider = new PhysicalFileProvider(
+                        Path.Combine(builder.Environment.ContentRootPath, "imagens")),
+                        RequestPath = "/imagens"
+                });
+            }
+            catch
             {
-                FileProvider = new PhysicalFileProvider(
-                    Path.Combine(builder.Environment.ContentRootPath, "imagens")),
-                RequestPath = "/imagens"
-            });
+                Directory.CreateDirectory("imagens");
+            }
 
             app.UseRouting();
 


### PR DESCRIPTION
Isso evita que cause a excessão FileNotFind, caso alguém rode o projeto pela primeira vez.